### PR TITLE
Python 3.9 

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install -r requirements.txt

--- a/learning/Dockerfile
+++ b/learning/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install -r requirements.txt

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install -r requirements.txt

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Here is the error I encountered with the command `docker-compose up -d`:

```sh
Could not build wheels for backports.zoneinfo, which is required to install pyproject.toml-based projects
```

Changing the Python version from 3.8 to 3.9 solved the problem :)